### PR TITLE
refactor: extract auth cookie logic and add CSRF validation

### DIFF
--- a/src/middleware/csrf.middleware.ts
+++ b/src/middleware/csrf.middleware.ts
@@ -1,0 +1,29 @@
+import type { Request as ExpressRequest, NextFunction, Response } from 'express'
+
+import crypto from 'node:crypto'
+
+export const validateCsrf = (
+  req: ExpressRequest,
+  res: Response,
+  next: NextFunction
+) => {
+  const csrfHeader = req.header('x-xsrf-token')
+  const csrfCookie = req.cookies['XSRF-TOKEN'] as string | undefined
+
+  if (!csrfHeader || !csrfCookie) {
+    return res.status(403).json({ error: 'Forbidden' })
+  }
+
+  const headerBuffer = Buffer.from(csrfHeader)
+  const cookieBuffer = Buffer.from(csrfCookie)
+
+  if (headerBuffer.length !== cookieBuffer.length) {
+    return res.status(403).json({ error: 'Forbidden' })
+  }
+
+  if (!crypto.timingSafeEqual(headerBuffer, cookieBuffer)) {
+    return res.status(403).json({ error: 'Forbidden' })
+  }
+
+  next()
+}

--- a/src/modules/users/user.controller.ts
+++ b/src/modules/users/user.controller.ts
@@ -27,34 +27,8 @@ class UserController {
 
     req.session.user = { id: user.id, username: user.username }
 
-    const accessToken = generateAccessToken({
-      id: user.id,
-    })
-    const refreshToken = generateRefreshToken()
-    const expiresAt = new Date(Date.now() + env.REFRESH_EXPIRES_IN * 1000)
-
-    await tokenRepository.save(
-      user.id,
-      refreshToken,
-      expiresAt,
-      req.get('user-agent')
-    )
-
-    res.cookie('refreshToken', refreshToken, {
-      httpOnly: true,
-      maxAge: env.REFRESH_EXPIRES_IN * 1000,
-      path: '/',
-      sameSite: 'strict',
-      secure: env.NODE_ENV === 'production',
-    })
-
-    res.cookie('XSRF-TOKEN', generateCsrfToken(), {
-      httpOnly: false,
-      maxAge: env.REFRESH_EXPIRES_IN * 1000,
-      path: '/',
-      sameSite: 'strict',
-      secure: env.NODE_ENV === 'production',
-    })
+    const accessToken = generateAccessToken({ id: user.id })
+    await this.setAuthCookies(res, user.id, req.get('user-agent'))
 
     res.status(200).json({
       ...user,
@@ -100,12 +74,11 @@ class UserController {
 
     req.session.user = { id: user.id, username: user.username }
 
+    const accessToken = generateAccessToken({ id: user.id })
     const newRefreshToken = generateRefreshToken()
     const expiresAt = new Date(Date.now() + env.REFRESH_EXPIRES_IN * 1000)
 
     await tokenRepository.rotateToken(refreshToken, newRefreshToken, expiresAt)
-
-    const accessToken = generateAccessToken({ id: oldRefreshToken.userId })
 
     res.cookie('refreshToken', newRefreshToken, {
       httpOnly: true,
@@ -134,18 +107,25 @@ class UserController {
 
     req.session.user = { id: user.id, username: user.username }
 
-    const accessToken = generateAccessToken({
-      id: user.id,
-    })
-    const refreshToken = generateRefreshToken()
-    const expiresAt = new Date(Date.now() + env.REFRESH_EXPIRES_IN * 1000)
+    const accessToken = generateAccessToken({ id: user.id })
+    await this.setAuthCookies(res, user.id, req.get('user-agent'))
 
-    await tokenRepository.save(
-      user.id,
-      refreshToken,
-      expiresAt,
-      req.get('user-agent')
-    )
+    res.status(201).json({
+      ...user,
+      expiresAt: Date.now() + env.JWT_ACCESS_EXPIRES_IN * 1000,
+      token: accessToken,
+    })
+  }
+
+  private async setAuthCookies(
+    res: Response,
+    userId: string,
+    deviceInfo?: string
+  ) {
+    const expiresAt = new Date(Date.now() + env.REFRESH_EXPIRES_IN * 1000)
+    const refreshToken = generateRefreshToken()
+
+    await tokenRepository.save(userId, refreshToken, expiresAt, deviceInfo)
 
     res.cookie('refreshToken', refreshToken, {
       httpOnly: true,
@@ -163,11 +143,7 @@ class UserController {
       secure: env.NODE_ENV === 'production',
     })
 
-    res.status(201).json({
-      ...user,
-      expiresAt: Date.now() + env.JWT_ACCESS_EXPIRES_IN * 1000,
-      token: accessToken,
-    })
+    return { expiresAt, refreshToken }
   }
 }
 

--- a/src/modules/users/user.routes.ts
+++ b/src/modules/users/user.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 
 import { authenticateToken } from '../../middleware/auth.middleware.js'
+import { validateCsrf } from '../../middleware/csrf.middleware.js'
 import { authLimiter } from '../../middleware/rateLimit.middleware.js'
 import { validateRequestBody } from '../../middleware/validate.middleware.js'
 import UserController from './user.controller.js'
@@ -20,8 +21,13 @@ userRouter.post(
   validateRequestBody(loginSchema),
   userController.login
 )
-userRouter.post('/refresh-token', authLimiter, userController.refreshToken)
-userRouter.post('/logout', authLimiter, userController.logout)
+userRouter.post(
+  '/refresh-token',
+  authLimiter,
+  validateCsrf,
+  userController.refreshToken
+)
+userRouter.post('/logout', authLimiter, validateCsrf, userController.logout)
 
 userRouter.get('/me', authenticateToken, userController.getMe)
 

--- a/test/integration/user.routes.test.ts
+++ b/test/integration/user.routes.test.ts
@@ -229,6 +229,7 @@ describe('Users Endpoints', () => {
 
   describe('POST /refresh-token', () => {
     let cookies: string[]
+    let csrfToken: string
 
     beforeAll(async () => {
       await TestHelpers.createTestUser()
@@ -239,12 +240,14 @@ describe('Users Endpoints', () => {
         .post('/api/v1/users/login')
         .send(TestHelpers.testUser)
       cookies = TestHelpers.extractCookies(res.headers['set-cookie'])
+      csrfToken = TestHelpers.extractCsrfToken(cookies)
     })
 
     test('should refresh token with valid refresh token', async () => {
       const res = await supertest(app)
         .post('/api/v1/users/refresh-token')
         .set('Cookie', cookies)
+        .set('x-xsrf-token', csrfToken)
 
       expect(res.status).toBe(200)
       expect(res.body).toHaveProperty('token')
@@ -253,8 +256,15 @@ describe('Users Endpoints', () => {
     })
 
     test('should return error when refresh token is missing', async () => {
-      const res = await supertest(app).post('/api/v1/users/refresh-token')
-      TestHelpers.assertAuthError(res)
+      const cookiesWithoutRefresh = cookies.filter(
+        (cookie) => !cookie.startsWith('refreshToken=')
+      )
+      const res = await supertest(app)
+        .post('/api/v1/users/refresh-token')
+        .set('Cookie', cookiesWithoutRefresh)
+        .set('x-xsrf-token', csrfToken)
+
+      expect(res.status).toBe(401)
     })
   })
 


### PR DESCRIPTION
- Extract setAuthCookies helper to reduce duplicate code
- Add validateCsrf middleware for CSRF-only validation
- Use CSRF validation for refresh-token and logout endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSRF validation enforced on refresh-token and logout endpoints (requests missing or mismatched CSRF token are rejected).

* **Refactor**
  * Unified cookie and token handling for login/register/refresh flows to standardize authentication behavior.

* **Tests**
  * Integration tests updated to include CSRF token handling for refresh-token and related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->